### PR TITLE
Fix editor assembly settings

### DIFF
--- a/Packages/UGF.UI/Editor/UGF.UI.Editor.asmdef
+++ b/Packages/UGF.UI/Editor/UGF.UI.Editor.asmdef
@@ -1,9 +1,12 @@
 {
     "name": "UGF.UI.Editor",
+    "rootNamespace": "UGF.UI.Editor",
     "references": [
         "GUID:97db1687e03501a4d90f208454febb18"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Packages/UGF.UI/Editor/UIEditorMenu.cs
+++ b/Packages/UGF.UI/Editor/UIEditorMenu.cs
@@ -6,7 +6,7 @@ namespace UGF.UI.Editor
 {
     internal static class UIEditorMenu
     {
-        [MenuItem("CONTEXT/RectTransform/Anchors To Corners", false, 2000)]
+        [MenuItem("CONTEXT/RectTransform/Anchors/Anchors To Corners", false, 2000)]
         private static void RectTransformAnchorsToCorners(MenuCommand menuCommand)
         {
             var rectTransform = (RectTransform)menuCommand.context;
@@ -16,7 +16,7 @@ namespace UGF.UI.Editor
             EditorUtility.SetDirty(rectTransform);
         }
 
-        [MenuItem("CONTEXT/RectTransform/Corners To Anchors", false, 2000)]
+        [MenuItem("CONTEXT/RectTransform/Anchors/Corners To Anchors", false, 2000)]
         private static void RectTransformCornersToAnchors(MenuCommand menuCommand)
         {
             var rectTransform = (RectTransform)menuCommand.context;

--- a/Packages/UGF.UI/Runtime/UGF.UI.Runtime.asmdef
+++ b/Packages/UGF.UI/Runtime/UGF.UI.Runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "UGF.UI.Runtime",
+    "rootNamespace": "UGF.UI.Runtime",
     "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.UI/Runtime/UIUtility.cs
+++ b/Packages/UGF.UI/Runtime/UIUtility.cs
@@ -12,16 +12,16 @@ namespace UGF.UI.Runtime
             if (rectTransform.parent is RectTransform parent)
             {
                 Rect rect = parent.rect;
-                Vector2 anchorsMin = Vector2.zero;
-                Vector2 anchorsMax = Vector2.zero;
+                Vector2 min = Vector2.zero;
+                Vector2 max = Vector2.zero;
 
-                anchorsMin.x = rectTransform.anchorMin.x + rectTransform.offsetMin.x / rect.width;
-                anchorsMin.y = rectTransform.anchorMin.y + rectTransform.offsetMin.y / rect.height;
-                anchorsMax.x = rectTransform.anchorMax.x + rectTransform.offsetMax.x / rect.width;
-                anchorsMax.y = rectTransform.anchorMax.y + rectTransform.offsetMax.y / rect.height;
+                min.x = rectTransform.anchorMin.x + rectTransform.offsetMin.x / rect.width;
+                min.y = rectTransform.anchorMin.y + rectTransform.offsetMin.y / rect.height;
+                max.x = rectTransform.anchorMax.x + rectTransform.offsetMax.x / rect.width;
+                max.y = rectTransform.anchorMax.y + rectTransform.offsetMax.y / rect.height;
 
-                rectTransform.anchorMin = anchorsMin;
-                rectTransform.anchorMax = anchorsMax;
+                rectTransform.anchorMin = min;
+                rectTransform.anchorMax = max;
                 rectTransform.offsetMin = Vector2.zero;
                 rectTransform.offsetMax = Vector2.zero;
             }

--- a/Packages/UGF.UI/package.json
+++ b/Packages/UGF.UI/package.json
@@ -16,10 +16,7 @@
   "changelogUrl": "https://github.com/unity-game-framework/ugf-ui/blob/master/license",
   "licenseUrl": "https://github.com/unity-game-framework/ugf-ui/blob/master/changelog.md",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/@unity-game-framework"
-  },
-  "bintray": {
-    "registry": "https://api.bintray.com/content/unity-game-framework/public"
+    "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
     "com.unity.modules.ui": "1.0.0"

--- a/Packages/UGF.UI/package.json
+++ b/Packages/UGF.UI/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.ui",
   "displayName": "UGF.UI",
   "version": "1.0.0",
-  "unity": "2020.1",
+  "unity": "2021.1",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Provides utilities to work with Unity UI.",
   "author": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "2.0.7",
-    "com.unity.test-framework": "1.1.16"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.29"
   },
   "scopedRegistries": [
     {
       "name": "Unity Game Framework",
-      "url": "https://api.bintray.com/npm/unity-game-framework/public",
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default",
       "scopes": [
         "com.ugf"
       ]

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -9,27 +9,27 @@
       }
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.0",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "2.0.7",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.1"
+        "com.unity.ext.nunit": "1.0.6"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.16",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.0",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -12,10 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_EnablePreviewPackages: 1
+  m_EnablePreReleasePackages: 0
   m_EnablePackageDependencies: 1
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
+  m_SeeAllPackageVersions: 0
   oneTimeWarningShown: 1
   m_Registries:
   - m_Id: main
@@ -26,26 +27,27 @@ MonoBehaviour:
     m_Capabilities: 7
   - m_Id: scoped:Unity Game Framework
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_IsDefault: 0
     m_Capabilities: 0
-  m_UserSelectedRegistryName: 
+  m_UserSelectedRegistryName: Unity Game Framework
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_ErrorMessage: 
     m_Original:
       m_Id: scoped:Unity Game Framework
       m_Name: Unity Game Framework
-      m_Url: https://api.bintray.com/npm/unity-game-framework/public
+      m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
       m_Scopes:
       - com.ugf
       m_IsDefault: 0
       m_Capabilities: 0
     m_Modified: 0
     m_Name: Unity Game Framework
-    m_Url: https://api.bintray.com/npm/unity-game-framework/public
+    m_Url: https://unitygameframework.jfrog.io/artifactory/api/npm/default
     m_Scopes:
     - com.ugf
     m_SelectedScopeIndex: 0
+  m_LoadAssets: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.1.5f1
-m_EditorVersionWithRevision: 2020.1.5f1 (e025938fdedc)
+m_EditorVersion: 2021.1.19f1
+m_EditorVersionWithRevision: 2021.1.19f1 (5f5eb8bbdc25)

--- a/UGF.UI.Editor.csproj.DotSettings
+++ b/UGF.UI.Editor.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Cugf_002Eui_005Ceditor/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
- Update package to _Unity_ of `2021.1` version.
- Fix editor assembly to be included only in editor platform.
- Change editor context menu for anchors, moved under the _Anchors_ menu.